### PR TITLE
Email

### DIFF
--- a/application/config/autoload.php
+++ b/application/config/autoload.php
@@ -141,6 +141,7 @@ $autoload['language'] = array();
 |	$autoload['model'] = array('first_model' => 'first');
 */
 $autoload['model'] = array(
+    'email_model',
 	'food_model', 
 	'food_category_model',
 	'food_review_model',

--- a/application/config/database.php
+++ b/application/config/database.php
@@ -77,7 +77,7 @@ $query_builder = TRUE;
 
 $db['default'] = array(
 	'dsn'	=> '',
-	'hostname' => 'localhost',
+	'hostname' => 'mysql',
 	'username' => $config["database_username"],
 	'password' => $config["database_password"],
 	'database' => 'yumbox_dev',

--- a/application/controllers/Mail_queue.php
+++ b/application/controllers/Mail_queue.php
@@ -5,6 +5,10 @@ class Mail_queue extends CI_Controller
 {
     public function serve($count = -1)
     {
+        if (php_sapi_name() !== 'cli') {
+            die('This method can only be executed through CLI');
+        }
+
         $this->load->library('mail_server');
 
         if ($count === -1) {

--- a/application/controllers/Mail_queue.php
+++ b/application/controllers/Mail_queue.php
@@ -1,0 +1,37 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Mail_queue extends CI_Controller
+{
+    public function serve($count = 10)
+    {
+        $this->load->library('mail_server');
+
+        for ($i=0; $i<$count; $i++) {
+            $mail = $this->email_model->getEmailFromQueue();
+            if ($mail === false) {
+                break;
+            }
+
+            try {
+                if ($this->mail_server->send(
+                    $mail->from_address,
+                    $mail->from_name,
+                    $mail->replyto,
+                    $mail->replyto_name,
+                    $mail->recipients,
+                    $mail->cc,
+                    $mail->bcc,
+                    $mail->subject,
+                    $mail->body
+                )
+                ) {
+                    $this->email_model->flagEmailSent($mail->mail_id);
+                }
+            }
+            catch (\Exception $ex) {
+                $this->email_model->incrementEmailTries($mail->mail_id);
+            }
+        }
+    }
+}

--- a/application/controllers/Mail_queue.php
+++ b/application/controllers/Mail_queue.php
@@ -3,9 +3,14 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 
 class Mail_queue extends CI_Controller
 {
-    public function serve($count = 10)
+    public function serve($count = -1)
     {
         $this->load->library('mail_server');
+
+        if ($count === -1) {
+            $this->config->load('secret_config', TRUE);
+            $count = (int)$this->config->item('queue_send_per_exe', 'secret_config');
+        }
 
         for ($i=0; $i<$count; $i++) {
             $mail = $this->email_model->getEmailFromQueue();

--- a/application/database/build_database.sql
+++ b/application/database/build_database.sql
@@ -541,3 +541,34 @@ insert into food_category (name, main) values ('drink', 1); #14
 insert into food_category (name, main) values ('italian', 1); #15
 insert into food_category (name, main) values ('mexican', 1); #16 
 insert into food_category (name, main) values ('persian', 1); #17 
+
+
+/** Email queue tables **/
+
+CREATE TABLE IF NOT EXISTS `mail_queue` (
+  `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `from_address` VARCHAR(255) NOT NULL,
+  `from_name` VARCHAR(255) NOT NULL,
+  `replyto` VARCHAR(255) NOT NULL,
+  `replyto_name` VARCHAR(255) NOT NULL,
+  `subject` VARCHAR(1024) NOT NULL,
+  `body` MEDIUMTEXT NOT NULL,
+  `enqueue_date` DATETIME NOT NULL,
+  `sent_date` DATETIME NOT NULL,
+  `tries` SMALLINT NOT NULL DEFAULT 0,
+  `try_date` DATETIME NOT NULL,
+  PRIMARY KEY (`id`))
+ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS `mail_recipient` (
+  `mail_id` BIGINT UNSIGNED NOT NULL,
+  `address` VARCHAR(255) NOT NULL,
+  `recipient_type` TINYINT NOT NULL,
+  `name` VARCHAR(255) NOT NULL,
+  PRIMARY KEY (`mail_id`, `address`, `recipient_type`),
+  CONSTRAINT `fk_mail_recipient_mail_queue`
+    FOREIGN KEY (`mail_id`)
+    REFERENCES `mail_queue` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION)
+ENGINE = InnoDB;

--- a/application/models/Email_model.php
+++ b/application/models/Email_model.php
@@ -1,0 +1,140 @@
+<?php
+if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+class Email_model extends CI_Model
+{
+    const RECIPIENT_TO = 0;
+    const RECIPIENT_CC = 1;
+    const RECIPIENT_BCC = 2;
+
+    public function addEmailToQueue($from_email, $from_name, $replyto_address, $replyto_name, array $recipients, array $cc, array $bcc, $subject, $body)
+    {
+        $this->db->trans_start();
+
+        if (!$this->db->query('
+            INSERT INTO mail_queue
+                (from_address, from_name, replyto, replyto_name, subject, body, enqueue_date, sent_date, tries, try_date)
+            VALUES
+                (?, ?, ?, ?, ?, ?, NOW(), \'0000-00-00 00:00:00\', 0, \'0000-00-00 00:00:00\')', array(
+                $from_email,
+                $from_name,
+                $replyto_address,
+                $replyto_name,
+                $subject,
+                $body,
+            ))
+        ) {
+            throw new Exception($this->db->error);
+        }
+
+        $mail_id = $this->db->insert_id();
+
+        $mail_recipients = array();
+        foreach ($recipients as $email => $name) {
+            $mail_recipients[] = $mail_id;
+            $mail_recipients[] = Email_model::RECIPIENT_TO;
+            $mail_recipients[] = $email;
+            $mail_recipients[] = $name;
+        }
+        foreach ($cc as $email => $name) {
+            $mail_recipients[] = $mail_id;
+            $mail_recipients[] = Email_model::RECIPIENT_CC;
+            $mail_recipients[] = $email;
+            $mail_recipients[] = $name;
+        }
+        foreach ($bcc as $email => $name) {
+            $mail_recipients[] = $mail_id;
+            $mail_recipients[] = Email_model::RECIPIENT_BCC;
+            $mail_recipients[] = $email;
+            $mail_recipients[] = $name;
+        }
+
+        if (!$this->db->query('
+            INSERT INTO mail_recipient
+                (mail_id, recipient_type, address, name)
+            VALUES
+                ' . implode(', ', array_fill(0, count($recipients) + count($cc) + count($bcc), '(?, ?, ?, ?)')), $mail_recipients)
+        ) {
+            throw new Exception($this->db->error);
+        }
+
+        $this->db->trans_complete();
+    }
+
+    public function getEmailFromQueue()
+    {
+        $query = $this->db->query('
+			SELECT
+				id AS mail_id, from_address, from_name, replyto, replyto_name, subject, body
+			FROM mail_queue
+			WHERE
+				sent_date = \'0000-00-00 00:00:00\'
+            ORDER BY try_date ASC, tries ASC, enqueue_date ASC
+            LIMIT 1');
+        $results = $query->result();
+
+        if (count($results) == 0)
+            return false;
+        else {
+            $mail = $results[0];
+            $mail->recipients = array();
+            $mail->cc = array();
+            $mail->bcc = array();
+
+            $query = $this->db->query('
+                SELECT
+                    recipient_type, address, name
+                FROM mail_recipient
+                WHERE
+                    mail_id = ?', array($mail->mail_id));
+            $results = $query->result();
+
+            foreach ($results as $r) {
+                switch ($r->recipient_type) {
+                    case Email_model::RECIPIENT_TO:
+                        $mail->recipients[$r->address] = $r->name;
+                        break;
+                    case Email_model::RECIPIENT_CC:
+                        $mail->cc[$r->address] = $r->name;
+                        break;
+                    case Email_model::RECIPIENT_BCC:
+                        $mail->bcc[$r->address] = $r->name;
+                        break;
+                }
+            }
+
+            return $mail;
+        }
+    }
+
+    public function flagEmailSent($mail_id)
+    {
+        if (!$this->db->query('
+            UPDATE mail_queue SET
+                tries = tries + 1,
+                try_date = NOW(),
+                sent_date = NOW()
+            WHERE
+                id = ?', array($mail_id))
+        ) {
+            throw new Exception($this->db->error);
+        }
+
+        return true;
+    }
+
+    public function incrementEmailTries($mail_id)
+    {
+        if (!$this->db->query('
+            UPDATE mail_queue SET
+                tries = tries + 1,
+                try_date = NOW(),
+            WHERE
+                id = ?', array($mail_id))
+        ) {
+            throw new Exception($this->db->error);
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
By this PR mails can be queued where they were sent before. This will improve the user experience as they don't need to wait for the email to be sent right away. Instead we need to run a scheduler to execute a command (mentioned below) to actually send the email periodically.

**TODO:** Two new database schemas are introduced to `applicaiton/database/build_database.sql`, namely table `mail_queue` and `mail_recipient`. Make sure these are created before you switch the mail queue functionality on.

**TODO:** New config to be added to `secret_config.php`

```
$config['queue_mail'] = '0'; // 0/1 to send the emails on the same request or queue them to be sent later (requires a cronjob)
$config['queue_send_per_exe'] = '10'; // How many emails should be sent per each execution
```

**TODO:** Setup a cronjob to run the following command on a regular basis

```
php project_folder/public/index.php Mail_queue serve
```
